### PR TITLE
chore: precompile headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.16)
 
 project(
 	goot

--- a/src/goot/CMakeLists.txt
+++ b/src/goot/CMakeLists.txt
@@ -47,6 +47,24 @@ target_include_directories(
 		${CMAKE_CURRENT_BINARY_DIR}
 )
 
+target_precompile_headers(
+	goot
+	PRIVATE
+		<algorithm>
+		<cstddef>
+		<numeric>
+		<ranges>
+		<span>
+		<string>
+		<string_view>
+		<utility>
+		<git2xx.hpp>
+		<QList>
+		<QObject>
+		<QString>
+		<QWidget>
+)
+
 target_link_libraries(
 	goot
 	PRIVATE

--- a/src/libgit2xx/git2xx.hpp
+++ b/src/libgit2xx/git2xx.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "git2xx/Error.hpp"
 #include "git2xx/Buffer.hpp"
-#include "git2xx/StrArray.hpp"
+#include "git2xx/Error.hpp"
 #include "git2xx/Git.hpp"
+#include "git2xx/Oid.hpp"
 #include "git2xx/Repository.hpp"
+#include "git2xx/StrArray.hpp"

--- a/src/libgit2xx/git2xx/Oid.hpp
+++ b/src/libgit2xx/git2xx/Oid.hpp
@@ -2,6 +2,7 @@
 
 #include "Error.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <exception>
 #include <git2/oid.h>


### PR DESCRIPTION
Compiling a set of headers ahead of time results in a massive speedup in compilation times, as those headers only need to be read, preprocessed, and parsed once.

With these changes, most C++ files only take a couple hundred milliseconds to compile.

Resolves #23.