### PR TITLE
chore: upgrade Qt to 6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ conan_cmake_configure(
 	REQUIRES
 		openssl/1.1.1m
 		libgit2/1.3.0
-		qt/6.2.4
+		qt/6.3.1
 	OPTIONS
 		qt:qttools=True
 		qt:shared=True

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,10 @@ include(3rd-party/cmake-conan/conan.cmake)
 
 conan_cmake_configure(
 	REQUIRES
-		openssl/1.1.1m
+		openssl/1.1.1q
 		libgit2/1.3.0
 		qt/6.3.1
+		zlib/1.2.12
 	OPTIONS
 		qt:qttools=True
 		qt:shared=True


### PR DESCRIPTION
6.4 is out, but it's not on conancenter yet.

I didn't change the CMakeLists file to use the new qt cmake functions because... ergh, it's going to take some more investigation. windeployqt only works in the install phase, which is a problem if I want to just run the app in the VS debugger... so that's going to take a separate ticket I think.

- [ ] Create a ticket to migrate windeployqt to the new cmake functions