### PR TITLE
fix(git2xx): a syntax error in Oid

### DIFF
--- a/src/libgit2xx/git2xx/Oid.hpp
+++ b/src/libgit2xx/git2xx/Oid.hpp
@@ -18,7 +18,7 @@ struct Oid : git_oid
 {
 	Oid()
 	{
-		std::ranges::fill(id, unsigned char {});
+		std::ranges::fill(id, (unsigned char){});
 	}
 
 	Oid(std::string_view str)


### PR DESCRIPTION
Complex type names (like 'unsigned char') need to be in parentheses when used in expressions. MSVC accepts it without them, but it's wrong apparently.